### PR TITLE
A bunch of small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ Next steps
 ==========
 
 Visit the following sites to learn more:
-
-http://www.ps2dev.org
-http://forums.ps2dev.org
+- https://en.wikibooks.org/wiki/PSP_Development
+- https://github.com/pspdev/pspsdk/tree/master/src/samples
+- http://psp.jim.sh/pspsdk-doc/

--- a/prepare.sh
+++ b/prepare.sh
@@ -40,6 +40,7 @@ _EOF_
 				subversion \
 				tcl \
 				texinfo \
+				unzip \
 				wget \
 				xz-utils \
 				zlib1g-dev

--- a/prepare.sh
+++ b/prepare.sh
@@ -43,45 +43,6 @@ _EOF_
 				wget \
 				xz-utils \
 				zlib1g-dev
-		elif command -v apt-get >/dev/null
-		then
-			if [ "$(id -u)" -ne "0" ]
-			then
-				cat >&2 <<_EOF_
-Warning: running without superuser privileges
-THIS IS MOST LIKELY GOING TO FAIL.
-Run this script using sudo, su or pkexec.
-_EOF_
-			fi
-
-			set -e
-
-			echo 'Installing dependency packages using legacy APT...'
-			apt-get install \
-				autoconf \
-				automake \
-				automake1.9 \
-				bison \
-				build-essential \
-				bzip2 \
-				cmake \
-				doxygen \
-				flex \
-				gcc \
-				git \
-				gzip \
-				g++ \
-				libelf-dev \
-				libfreetype6-dev \
-				libncurses5-dev \
-				libreadline-dev \
-				libusb-dev \
-				libtool \
-				subversion \
-				tcl \
-				texinfo \
-				xz-utils \
-				zlib1g-dev
 		elif command -v dnf >/dev/null 2>&1
 		then
 			cat >&2 <<_EOF_

--- a/prepare.sh
+++ b/prepare.sh
@@ -3,7 +3,7 @@
 case "$(uname -s)" in
 	Linux)
 
-		if command -v apt >/dev/null 2>&1
+		if command -v apt-get >/dev/null 2>&1
 		then
 			if [ "$(id -u)" -ne "0" ]
 			then
@@ -17,7 +17,7 @@ _EOF_
 			set -e
 
 			echo 'Installing dependency packages using APT...'
-			apt install \
+			apt-get install \
 				autoconf \
 				automake \
 				bison \


### PR DESCRIPTION
This pull request contains the following changes:
- Adding useful links at the bottom of the README. The current ones go to websites which don't exist anymore.
- Add unzip to the dependencies to be installed for systems using apt.
- Remove duplicate code in the prepare script. I'm pretty sure there are currently no systems which do have apt, but not apt-get and vice versa. In the past apt used to not be shipped with all Debian based systems, but all the currently supported ones should have both. Although, if you really want to be on the safe side, I could change it to use apt-get instead.