### PR TITLE
Enable plugin support

### DIFF
--- a/gcc.sh
+++ b/gcc.sh
@@ -36,7 +36,7 @@ mkdir build-psp
 cd build-psp
 
 ## Configure the build.
-../configure --prefix="$PSPDEV" --target="psp" --enable-languages="c,lto$EXTRA_LANGUAGES" --enable-lto --with-newlib --with-system-zlib $EXTRA_CONFIGURE_FLAGS
+../configure --prefix="$PSPDEV" --target="psp" --enable-languages="c,lto$EXTRA_LANGUAGES" --enable-lto --enable-plugins --with-newlib --with-system-zlib $EXTRA_CONFIGURE_FLAGS
 
 ## Compile and install.
 run_make

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -25,9 +25,9 @@ mkdir build-psp
 cd build-psp
 
 # Configure the build.
-../configure --prefix="$PSPDEV" --target="psp" --enable-install-libbfd --disable-werror --with-system-zlib
+../configure --prefix="$PSPDEV" --target="psp" --enable-install-libbfd --enable-plugins --disable-werror --with-system-zlib
 
 # Compile and install.
-run_make 
+run_make
 run_make install
 run_make clean


### PR DESCRIPTION
Plugin Support will allow things like imgui to function as psp-gcc-ar complains about not having plugin support enabled by default.
